### PR TITLE
Removed reference to Openstack Blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,5 @@ Development is active. Can be used for individual testing.
 ## Contributions
 Contributions are welcome. Specifically following areas need help:
 
-1. Similar drivers for Windows Azure, Google Compute Engine and other public cloud providers
-2. Following blueprints track the integration with OpenStack:
-   * Nova: https://blueprints.launchpad.net/nova/+spec/nova-aws
-   * Neutron: https://bugs.launchpad.net/neutron/+bug/1638399
-   * Glance: https://blueprints.launchpad.net/glance/+spec/glance-aws
-   * Cinder: https://blueprints.launchpad.net/cinder/+spec/cinder-aws
-   
-   Help is needed in promoting these blueprints for next (O) release.
+1. Similar drivers for Windows Azure, Google Compute Engine and other public cloud providers.
+2. Build/deploy tools to easily add drivers to projects like Nova, Neutron, Glance and Cinder.


### PR DESCRIPTION
Omni is now being proposed as Big Tent project. Individual project proposals are no longer relevant.